### PR TITLE
Add Dockerfile for Node v22 with ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:22-alpine
+
+# Install ffmpeg
+RUN apk add --no-cache ffmpeg
+
+# Create app directory
+WORKDIR /app
+
+# Copy package.json and lock file
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install --production=false
+
+# Copy source code
+COPY . .
+
+# Build the project
+RUN npm run build
+
+# Expose application port
+EXPOSE 3000
+
+# Start the server
+CMD ["node", "backend/index.js"]

--- a/README.MD
+++ b/README.MD
@@ -28,12 +28,11 @@ npm run build
 
 ### **Docker (Recommended)**
 ```bash
-# Build and run with Docker Compose
-npm run docker:build
-npm run docker:up
+# Build image
+docker build -t cs-backend .
 
-# Stop containers
-npm run docker:down
+# Run locally
+docker run -p 3000:3000 cs-backend
 ```
 
 ### **Azure Container Registry**
@@ -43,6 +42,11 @@ docker pull csanalyzer.azurecr.io/cs-backend:latest
 
 # Run from registry
 docker run -p 3000:3000 csanalyzer.azurecr.io/cs-backend:latest
+
+# Push your build
+az acr login --name <ACR_NAME>
+docker tag cs-backend <ACR_NAME>.azurecr.io/cs-backend:latest
+docker push <ACR_NAME>.azurecr.io/cs-backend:latest
 ```
 
 ## 📚 Documentation


### PR DESCRIPTION
## Summary
- add Dockerfile based on Node.js 22 including ffmpeg
- document Docker usage and pushing image to Azure Container Registry

## Testing
- `npm test`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6366e6888330a444c63ed623cb5a