### PR TITLE
feat: US-002 - Create Team After User Registration

### DIFF
--- a/src/controllers/authentication.ts
+++ b/src/controllers/authentication.ts
@@ -11,10 +11,20 @@ function buildAuthenticationController(): IAuthentication {
     };
 
     // Callback de Steam después de la autenticación
+    // US-002: After successful auth, redirect to team creation if user has no teams
     const steamCallback = async (req: Request, res: Response) => {
         passport.authenticate("steam", { failureRedirect: "/login" })(
-        req,res,() => {
+        req, res, async () => {
             console.log("User authenticated successfully:", req.user);
+            const steamUser = req.user as any;
+            if (steamUser) {
+                const user = await database.getUserBySteamId(steamUser.id);
+                if (user && user.teamIds && user.teamIds.length === 0) {
+                    // New user (no teams yet) – prompt team creation
+                    res.redirect('/?needsTeamSetup=true');
+                    return;
+                }
+            }
             res.redirect("/");
         });
     };

--- a/src/controllers/db/schemas.ts
+++ b/src/controllers/db/schemas.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema } from 'mongoose';
+import mongoose, { Schema, Types } from 'mongoose';
 
 // Define the schema for the User model
 export interface IUserModel extends Document {
@@ -23,12 +23,37 @@ export interface IUserModel extends Document {
   personastateflags?: number;
   loccountrycode?: string;
   locstatecode?: string;
+  // US-001: Team associations – array of team IDs the user belongs to
+  teamIds: Types.ObjectId[];
 }
 
 export interface IGenerationModel extends Document {
   steamId: string;
   dateTime: string;
   responseLLM: string;
+}
+
+// US-001: Team member entry with role for ACL
+export interface ITeamMember {
+  userId: Types.ObjectId;
+  role: 'Admin' | 'Editor' | 'Viewer';
+}
+
+// US-001: Team model – owns projects and has members
+export interface ITeamModel extends Document {
+  name: string;
+  slug: string;
+  description?: string;
+  ownerId: Types.ObjectId;
+  members: ITeamMember[];
+}
+
+// US-001: Project model – belongs to a team
+export interface IProjectModel extends Document {
+  name: string;
+  teamId: Types.ObjectId;
+  ticketSlug: string;
+  statusOptions: string[];
 }
 
 const userSchema = new Schema({
@@ -52,7 +77,9 @@ const userSchema = new Schema({
     timecreated: { type: Number, required: false },
     personastateflags: { type: Number, required: false },
     loccountrycode: { type: String, required: false },
-    locstatecode: { type: String, required: false }
+    locstatecode: { type: String, required: false },
+    // US-001: array of team ObjectIds for fast membership lookups
+    teamIds: [{ type: Schema.Types.ObjectId, ref: 'Teams', default: [] }],
 }, {
     timestamps: true,
 });
@@ -65,6 +92,32 @@ const generationSchema = new Schema({
     timestamps: true,
 });
 
+// US-001: Team schema – index on slug for fast lookups
+const teamSchema = new Schema<ITeamModel>({
+    name: { type: String, required: true },
+    slug: { type: String, required: true, unique: true, index: true },
+    description: { type: String },
+    ownerId: { type: Schema.Types.ObjectId, ref: 'Users', required: true, index: true },
+    members: [{
+        userId: { type: Schema.Types.ObjectId, ref: 'Users', required: true },
+        role: { type: String, enum: ['Admin', 'Editor', 'Viewer'], default: 'Viewer' },
+    }],
+}, {
+    timestamps: true,
+});
+
+// US-001: Project schema – index on teamId for fast ACL queries
+const projectSchema = new Schema<IProjectModel>({
+    name: { type: String, required: true },
+    teamId: { type: Schema.Types.ObjectId, ref: 'Teams', required: true, index: true },
+    ticketSlug: { type: String, required: true, unique: true },
+    statusOptions: { type: [String], default: ['Backlog', 'Todo', 'In Progress', 'Done'] },
+}, {
+    timestamps: true,
+});
+
 export const User = mongoose.model<IUserModel>('Users', userSchema);
 export const Generation = mongoose.model<IGenerationModel>('Generations', generationSchema);
+export const Team = mongoose.model<ITeamModel>('Teams', teamSchema);
+export const Project = mongoose.model<IProjectModel>('Projects', projectSchema);
 

--- a/src/controllers/team.ts
+++ b/src/controllers/team.ts
@@ -1,0 +1,102 @@
+import type { Request, Response } from 'express';
+import { Team, User } from './db/schemas.js';
+
+// Generates a URL-safe slug from a team name
+function toSlug(name: string): string {
+    return name
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+// Finds a unique slug by appending -1, -2, etc. if needed
+async function uniqueSlug(base: string): Promise<string> {
+    let slug = base;
+    let suffix = 0;
+    while (await Team.exists({ slug })) {
+        suffix += 1;
+        slug = `${base}-${suffix}`;
+    }
+    return slug;
+}
+
+function buildTeamController() {
+    // POST /api/v1/teams – create a new team for the authenticated user
+    const createTeam = async (req: Request, res: Response) => {
+        try {
+            const steamUser = req.user as any;
+            if (!steamUser) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const { name, description, slug: requestedSlug } = req.body as {
+                name: string;
+                description?: string;
+                slug?: string;
+            };
+
+            if (!name || typeof name !== 'string' || name.trim().length === 0) {
+                res.status(400).json({ error: 'Team name is required' });
+                return;
+            }
+
+            // Look up the user document by steamId
+            const user = await User.findOne({ steamId: steamUser.id });
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            // Resolve slug
+            const baseSlug = requestedSlug ? toSlug(requestedSlug) : toSlug(name);
+            const slug = await uniqueSlug(baseSlug);
+
+            // Create team with the user as owner and admin member
+            const team = new Team({
+                name: name.trim(),
+                slug,
+                description: description?.trim(),
+                ownerId: user._id,
+                members: [{ userId: user._id, role: 'Admin' }],
+            });
+            await team.save();
+
+            // Add this team to the user's teamIds array
+            await User.updateOne({ _id: user._id }, { $addToSet: { teamIds: team._id } });
+
+            res.status(201).json({ team });
+        } catch (error) {
+            console.error('Error creating team:', error);
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+
+    // GET /api/v1/teams – list teams for the authenticated user
+    const getMyTeams = async (req: Request, res: Response) => {
+        try {
+            const steamUser = req.user as any;
+            if (!steamUser) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const user = await User.findOne({ steamId: steamUser.id });
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            const teams = await Team.find({ _id: { $in: user.teamIds } });
+            res.status(200).json({ teams });
+        } catch (error) {
+            console.error('Error fetching teams:', error);
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+
+    return { createTeam, getMyTeams };
+}
+
+export default buildTeamController;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import helmet from 'helmet';
 import bodyParser from 'body-parser';
 import { IConfiguration } from './types/index.js';
 import database from './controllers/db/database.js';
-import { buildUserRouter , buildGenerationRouter, buildAuthRouter } from './routes/v1/index.js';
+import { buildUserRouter , buildGenerationRouter, buildAuthRouter, buildTeamRouter } from './routes/v1/index.js';
 import buildDocsRouter from './routes/v1/docs.js';
 import { initializeFFmpeg } from './config/ffmpeg.js';
 
@@ -50,6 +50,9 @@ app.use(authMiddleware);
 app.use('/auth', authRouter);
 
 app.use('/api/v1/users', buildUserRouter());
+
+// US-002: Team management endpoints (create team, list teams)
+app.use('/api/v1/teams', buildTeamRouter());
 
 app.use((req, res, next) => {
     // Middleware para manejar errores

--- a/src/middleware/acl.ts
+++ b/src/middleware/acl.ts
@@ -1,0 +1,82 @@
+/**
+ * US-001: ACL middleware for team-based access control.
+ * Ensures that only team members can access team-gated resources.
+ */
+import type { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
+import { Project, Team } from '../controllers/db/schemas.js';
+
+/**
+ * Express middleware that verifies the authenticated user belongs to the team
+ * associated with the requested project (resolved from req.params.projectId).
+ *
+ * Usage: router.get('/projects/:projectId/...', requireTeamMembership, handler)
+ */
+export async function requireTeamMembership(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const user = req.user as { _id?: string; steamId?: string } | undefined;
+
+  if (!user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { projectId, teamId } = req.params;
+
+  try {
+    let resolvedTeamId: string | undefined = teamId;
+
+    // If we have a projectId, resolve the teamId from the project
+    if (projectId && !resolvedTeamId) {
+      if (!mongoose.Types.ObjectId.isValid(projectId)) {
+        res.status(400).json({ error: 'Invalid project ID' });
+        return;
+      }
+      const project = await Project.findById(projectId).select('teamId').lean();
+      if (!project) {
+        res.status(404).json({ error: 'Project not found' });
+        return;
+      }
+      resolvedTeamId = project.teamId.toString();
+    }
+
+    if (!resolvedTeamId) {
+      res.status(400).json({ error: 'Team or project ID required' });
+      return;
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(resolvedTeamId)) {
+      res.status(400).json({ error: 'Invalid team ID' });
+      return;
+    }
+
+    // Look up the team and check membership
+    const team = await Team.findById(resolvedTeamId)
+      .select('ownerId members')
+      .lean();
+
+    if (!team) {
+      res.status(404).json({ error: 'Team not found' });
+      return;
+    }
+
+    const userId = (user as any)._id?.toString() ?? (user as any).id?.toString();
+
+    const isOwner = team.ownerId.toString() === userId;
+    const isMember = team.members.some((m) => m.userId.toString() === userId);
+
+    if (!isOwner && !isMember) {
+      res.status(403).json({ error: 'Forbidden: not a team member' });
+      return;
+    }
+
+    // Attach team to request for downstream handlers
+    (req as any).team = team;
+    next();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/middleware/populate.ts
+++ b/src/middleware/populate.ts
@@ -1,0 +1,61 @@
+/**
+ * US-001: Middleware to populate MongoDB associations.
+ * Attaches populated data to requests so route handlers don't repeat queries.
+ */
+import type { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
+import { Project } from '../controllers/db/schemas.js';
+
+/**
+ * Populates a project document with its team members using MongoDB $lookup.
+ * Attaches the result to req.populatedProject.
+ *
+ * Usage: router.get('/projects/:projectId', populateProject, handler)
+ */
+export async function populateProject(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const { projectId } = req.params;
+
+  if (!projectId || !mongoose.Types.ObjectId.isValid(projectId)) {
+    res.status(400).json({ error: 'Invalid project ID' });
+    return;
+  }
+
+  try {
+    // Use $lookup to join project -> team -> members (users) in a single query
+    const results = await Project.aggregate([
+      { $match: { _id: new mongoose.Types.ObjectId(projectId) } },
+      {
+        $lookup: {
+          from: 'teams',
+          localField: 'teamId',
+          foreignField: '_id',
+          as: 'team',
+        },
+      },
+      { $unwind: { path: '$team', preserveNullAndEmptyArrays: true } },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'team.members.userId',
+          foreignField: '_id',
+          as: 'teamMembers',
+          pipeline: [{ $project: { steamId: 1, displayName: 1, avatarUrl: 1 } }],
+        },
+      },
+    ]);
+
+    if (!results.length) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+
+    (req as any).populatedProject = results[0];
+    next();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/migrations/001-add-team-associations.ts
+++ b/src/migrations/001-add-team-associations.ts
@@ -1,0 +1,68 @@
+/**
+ * US-001: Migration – add team association fields to existing collections.
+ *
+ * Run with:
+ *   npx tsx src/migrations/001-add-team-associations.ts
+ *
+ * Safe to run multiple times (idempotent via $setOnInsert / default values).
+ */
+import mongoose from 'mongoose';
+
+const MONGO_URI =
+  process.env.AZURE_COSMOS_CONNECTIONSTRING ||
+  process.env.DATABASE_URL ||
+  'mongodb://localhost:27017/cs_ai_analyzer';
+
+async function runMigration(): Promise<void> {
+  await mongoose.connect(MONGO_URI);
+  console.log('Connected to MongoDB:', MONGO_URI);
+
+  const db = mongoose.connection.db;
+  if (!db) throw new Error('Database connection not available');
+
+  // 1. Add teamIds array (default []) to all Users that lack the field
+  const usersResult = await db.collection('users').updateMany(
+    { teamIds: { $exists: false } },
+    { $set: { teamIds: [] } }
+  );
+  console.log(`Users updated: ${usersResult.modifiedCount}`);
+
+  // 2. Ensure indexes on Users.teamIds for fast team-membership queries
+  await db.collection('users').createIndex({ teamIds: 1 }, { background: true });
+  console.log('Index on users.teamIds ensured');
+
+  // 3. Ensure Teams collection exists with required indexes
+  const teamsColl = await db
+    .listCollections({ name: 'teams' })
+    .toArray();
+  if (teamsColl.length === 0) {
+    await db.createCollection('teams');
+    console.log('Created teams collection');
+  }
+  await db.collection('teams').createIndex({ slug: 1 }, { unique: true, background: true });
+  await db.collection('teams').createIndex({ ownerId: 1 }, { background: true });
+  await db.collection('teams').createIndex({ 'members.userId': 1 }, { background: true });
+  console.log('Indexes on teams collection ensured');
+
+  // 4. Ensure Projects collection exists with required indexes
+  const projectsColl = await db
+    .listCollections({ name: 'projects' })
+    .toArray();
+  if (projectsColl.length === 0) {
+    await db.createCollection('projects');
+    console.log('Created projects collection');
+  }
+  await db.collection('projects').createIndex({ teamId: 1 }, { background: true });
+  await db
+    .collection('projects')
+    .createIndex({ ticketSlug: 1 }, { unique: true, background: true });
+  console.log('Indexes on projects collection ensured');
+
+  await mongoose.disconnect();
+  console.log('Migration 001 completed successfully.');
+}
+
+runMigration().catch((err) => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -1,3 +1,4 @@
 export { default as buildUserRouter } from './user.js';
 export { default as buildGenerationRouter } from './generation.js';
 export { default as buildAuthRouter } from './auth.js';
+export { default as buildTeamRouter } from './team.js';

--- a/src/routes/v1/team.ts
+++ b/src/routes/v1/team.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import buildTeamController from '../../controllers/team.js';
+
+function buildTeamRouter() {
+    const router = express.Router();
+    const { createTeam, getMyTeams } = buildTeamController();
+
+    // List teams for the authenticated user
+    router.get('/', getMyTeams);
+
+    // Create a new team
+    router.post('/', createTeam);
+
+    return router;
+}
+
+export default buildTeamRouter;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,4 +1,4 @@
-import type { IUserModel, IGenerationModel } from '../controllers/db/schemas.js';
+import type { IUserModel, IGenerationModel, ITeamModel, IProjectModel } from '../controllers/db/schemas.js';
 import { ISteamProfile } from './auth.js';
 
 export interface Database {


### PR DESCRIPTION
## US-002: Create Team After User Registration

### Summary
Adds a team creation endpoint so that newly authenticated users can create a team immediately after Steam login. The auth callback now detects first-time users (no teams) and redirects them to a team setup flow via `?needsTeamSetup=true`.

### Changes
- **`src/controllers/team.ts`**: New controller with `createTeam` (POST) and `getMyTeams` (GET) handlers. Auto-generates unique team slug from name.
- **`src/routes/v1/team.ts`**: New Express router mounting `GET /` and `POST /` on `/api/v1/teams`.
- **`src/routes/v1/index.ts`**: Export `buildTeamRouter`.
- **`src/index.ts`**: Register team router at `/api/v1/teams`.
- **`src/controllers/authentication.ts`**: After Steam callback, check if user has no teams and redirect to `/?needsTeamSetup=true`.

### Acceptance Criteria
- [x] After successful Steam auth, redirect includes `?needsTeamSetup=true` for new users with no teams
- [x] `POST /api/v1/teams` creates team document with user as owner (Admin role)
- [x] Auto-generates unique team slug from name
- [x] User document updated with new `teamId` via `$addToSet`
- [x] `GET /api/v1/teams` returns teams for authenticated user
- [x] Typecheck passes
- [x] All existing tests pass

### Notes
- No browser tools available for UI verification (backend-only service)

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable first-time users to create a team right after Steam login and add team APIs under /api/v1/teams. Introduces user–team–project models and ACL groundwork for team-scoped access.

- **New Features**
  - Satisfies US-002: redirect with ?needsTeamSetup=true for new users; POST /api/v1/teams creates a team with a unique slug and sets creator as Admin; GET /api/v1/teams lists the user’s teams.
  - Adds Team and Project schemas and User.teamIds; mounts /api/v1/teams router.
  - Adds requireTeamMembership ACL and populateProject middleware for future team-protected routes.

- **Migration**
  - Run: npx tsx src/migrations/001-add-team-associations.ts to add teamIds and ensure indexes/collections.
  - Safe to run multiple times.

<sup>Written for commit cb1b85be24fd29ba3c2471408cc25d03b52bb758. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

