### PR TITLE
feat: US-003 - Create Project Linked to Team

### DIFF
--- a/src/controllers/authentication.ts
+++ b/src/controllers/authentication.ts
@@ -11,10 +11,20 @@ function buildAuthenticationController(): IAuthentication {
     };
 
     // Callback de Steam después de la autenticación
+    // US-002: After successful auth, redirect to team creation if user has no teams
     const steamCallback = async (req: Request, res: Response) => {
         passport.authenticate("steam", { failureRedirect: "/login" })(
-        req,res,() => {
+        req, res, async () => {
             console.log("User authenticated successfully:", req.user);
+            const steamUser = req.user as any;
+            if (steamUser) {
+                const user = await database.getUserBySteamId(steamUser.id);
+                if (user && user.teamIds && user.teamIds.length === 0) {
+                    // New user (no teams yet) – prompt team creation
+                    res.redirect('/?needsTeamSetup=true');
+                    return;
+                }
+            }
             res.redirect("/");
         });
     };

--- a/src/controllers/db/schemas.ts
+++ b/src/controllers/db/schemas.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema } from 'mongoose';
+import mongoose, { Schema, Types } from 'mongoose';
 
 // Define the schema for the User model
 export interface IUserModel extends Document {
@@ -23,12 +23,37 @@ export interface IUserModel extends Document {
   personastateflags?: number;
   loccountrycode?: string;
   locstatecode?: string;
+  // US-001: Team associations – array of team IDs the user belongs to
+  teamIds: Types.ObjectId[];
 }
 
 export interface IGenerationModel extends Document {
   steamId: string;
   dateTime: string;
   responseLLM: string;
+}
+
+// US-001: Team member entry with role for ACL
+export interface ITeamMember {
+  userId: Types.ObjectId;
+  role: 'Admin' | 'Editor' | 'Viewer';
+}
+
+// US-001: Team model – owns projects and has members
+export interface ITeamModel extends Document {
+  name: string;
+  slug: string;
+  description?: string;
+  ownerId: Types.ObjectId;
+  members: ITeamMember[];
+}
+
+// US-001: Project model – belongs to a team
+export interface IProjectModel extends Document {
+  name: string;
+  teamId: Types.ObjectId;
+  ticketSlug: string;
+  statusOptions: string[];
 }
 
 const userSchema = new Schema({
@@ -52,7 +77,9 @@ const userSchema = new Schema({
     timecreated: { type: Number, required: false },
     personastateflags: { type: Number, required: false },
     loccountrycode: { type: String, required: false },
-    locstatecode: { type: String, required: false }
+    locstatecode: { type: String, required: false },
+    // US-001: array of team ObjectIds for fast membership lookups
+    teamIds: [{ type: Schema.Types.ObjectId, ref: 'Teams', default: [] }],
 }, {
     timestamps: true,
 });
@@ -65,6 +92,32 @@ const generationSchema = new Schema({
     timestamps: true,
 });
 
+// US-001: Team schema – index on slug for fast lookups
+const teamSchema = new Schema<ITeamModel>({
+    name: { type: String, required: true },
+    slug: { type: String, required: true, unique: true, index: true },
+    description: { type: String },
+    ownerId: { type: Schema.Types.ObjectId, ref: 'Users', required: true, index: true },
+    members: [{
+        userId: { type: Schema.Types.ObjectId, ref: 'Users', required: true },
+        role: { type: String, enum: ['Admin', 'Editor', 'Viewer'], default: 'Viewer' },
+    }],
+}, {
+    timestamps: true,
+});
+
+// US-001: Project schema – index on teamId for fast ACL queries
+const projectSchema = new Schema<IProjectModel>({
+    name: { type: String, required: true },
+    teamId: { type: Schema.Types.ObjectId, ref: 'Teams', required: true, index: true },
+    ticketSlug: { type: String, required: true, unique: true },
+    statusOptions: { type: [String], default: ['Backlog', 'Todo', 'In Progress', 'Done'] },
+}, {
+    timestamps: true,
+});
+
 export const User = mongoose.model<IUserModel>('Users', userSchema);
 export const Generation = mongoose.model<IGenerationModel>('Generations', generationSchema);
+export const Team = mongoose.model<ITeamModel>('Teams', teamSchema);
+export const Project = mongoose.model<IProjectModel>('Projects', projectSchema);
 

--- a/src/controllers/project.ts
+++ b/src/controllers/project.ts
@@ -1,0 +1,185 @@
+import type { Request, Response } from 'express';
+import { Project, Team, User } from './db/schemas.js';
+
+// Validates ticket slug format: 3-4 uppercase letters followed by a hyphen (e.g., "TKT-")
+function isValidTicketSlug(slug: string): boolean {
+    return /^[A-Z]{3,4}-$/.test(slug);
+}
+
+function buildProjectController() {
+    // POST /api/v1/projects – create a new project linked to a team
+    const createProject = async (req: Request, res: Response) => {
+        try {
+            const steamUser = req.user as any;
+            if (!steamUser) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const { name, teamId, ticketSlug } = req.body as {
+                name: string;
+                teamId: string;
+                ticketSlug: string;
+            };
+
+            if (!name || typeof name !== 'string' || name.trim().length === 0) {
+                res.status(400).json({ error: 'Project name is required' });
+                return;
+            }
+
+            if (!teamId || typeof teamId !== 'string') {
+                res.status(400).json({ error: 'teamId is required' });
+                return;
+            }
+
+            if (!ticketSlug || !isValidTicketSlug(ticketSlug)) {
+                res.status(400).json({
+                    error: 'ticketSlug must be 3-4 uppercase letters followed by a hyphen (e.g., "TKT-")',
+                });
+                return;
+            }
+
+            // Verify the team exists
+            const team = await Team.findById(teamId);
+            if (!team) {
+                res.status(404).json({ error: 'Team not found' });
+                return;
+            }
+
+            // Verify the requesting user is a member of the team
+            const user = await User.findOne({ steamId: steamUser.id });
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            const isMember = team.members.some(
+                (m) => m.userId.toString() === (user._id as any).toString()
+            );
+            const isOwner = team.ownerId.toString() === (user._id as any).toString();
+
+            if (!isMember && !isOwner) {
+                res.status(403).json({ error: 'Forbidden: you must be a team member to create a project' });
+                return;
+            }
+
+            // Ensure ticketSlug is unique
+            const existing = await Project.findOne({ ticketSlug });
+            if (existing) {
+                res.status(409).json({ error: `Ticket slug "${ticketSlug}" is already in use` });
+                return;
+            }
+
+            const project = new Project({
+                name: name.trim(),
+                teamId: team._id,
+                ticketSlug,
+                statusOptions: ['Backlog', 'Todo', 'In Progress', 'Done'],
+            });
+            await project.save();
+
+            // Generate the first example ticket ID for display
+            const prefix = ticketSlug; // e.g., "TKT-"
+            const firstTicketExample = `${prefix}001`;
+
+            res.status(201).json({ project, firstTicketExample });
+        } catch (error) {
+            console.error('Error creating project:', error);
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+
+    // GET /api/v1/teams/:teamId/projects – list projects for a team (team members only)
+    const getTeamProjects = async (req: Request, res: Response) => {
+        try {
+            const steamUser = req.user as any;
+            if (!steamUser) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const { teamId } = req.params;
+
+            const team = await Team.findById(teamId);
+            if (!team) {
+                res.status(404).json({ error: 'Team not found' });
+                return;
+            }
+
+            const user = await User.findOne({ steamId: steamUser.id });
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            const isMember = team.members.some(
+                (m) => m.userId.toString() === (user._id as any).toString()
+            );
+            const isOwner = team.ownerId.toString() === (user._id as any).toString();
+
+            if (!isMember && !isOwner) {
+                res.status(403).json({ error: 'Forbidden: not a team member' });
+                return;
+            }
+
+            const projects = await Project.find({ teamId: team._id });
+            res.status(200).json({ projects });
+        } catch (error) {
+            console.error('Error fetching projects:', error);
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+
+    // GET /api/v1/projects/:projectId – get a single project (team members only)
+    const getProject = async (req: Request, res: Response) => {
+        try {
+            const steamUser = req.user as any;
+            if (!steamUser) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const { projectId } = req.params;
+
+            const project = await Project.findById(projectId);
+            if (!project) {
+                res.status(404).json({ error: 'Project not found' });
+                return;
+            }
+
+            const team = await Team.findById(project.teamId);
+            if (!team) {
+                res.status(404).json({ error: 'Team not found' });
+                return;
+            }
+
+            const user = await User.findOne({ steamId: steamUser.id });
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            const isMember = team.members.some(
+                (m) => m.userId.toString() === (user._id as any).toString()
+            );
+            const isOwner = team.ownerId.toString() === (user._id as any).toString();
+
+            if (!isMember && !isOwner) {
+                res.status(403).json({ error: 'Forbidden: not a team member' });
+                return;
+            }
+
+            const prefix = project.ticketSlug;
+            const firstTicketExample = `${prefix}001`;
+
+            res.status(200).json({ project, firstTicketExample });
+        } catch (error) {
+            console.error('Error fetching project:', error);
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+
+    return { createProject, getTeamProjects, getProject };
+}
+
+export default buildProjectController;

--- a/src/controllers/team.ts
+++ b/src/controllers/team.ts
@@ -1,0 +1,102 @@
+import type { Request, Response } from 'express';
+import { Team, User } from './db/schemas.js';
+
+// Generates a URL-safe slug from a team name
+function toSlug(name: string): string {
+    return name
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+// Finds a unique slug by appending -1, -2, etc. if needed
+async function uniqueSlug(base: string): Promise<string> {
+    let slug = base;
+    let suffix = 0;
+    while (await Team.exists({ slug })) {
+        suffix += 1;
+        slug = `${base}-${suffix}`;
+    }
+    return slug;
+}
+
+function buildTeamController() {
+    // POST /api/v1/teams – create a new team for the authenticated user
+    const createTeam = async (req: Request, res: Response) => {
+        try {
+            const steamUser = req.user as any;
+            if (!steamUser) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const { name, description, slug: requestedSlug } = req.body as {
+                name: string;
+                description?: string;
+                slug?: string;
+            };
+
+            if (!name || typeof name !== 'string' || name.trim().length === 0) {
+                res.status(400).json({ error: 'Team name is required' });
+                return;
+            }
+
+            // Look up the user document by steamId
+            const user = await User.findOne({ steamId: steamUser.id });
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            // Resolve slug
+            const baseSlug = requestedSlug ? toSlug(requestedSlug) : toSlug(name);
+            const slug = await uniqueSlug(baseSlug);
+
+            // Create team with the user as owner and admin member
+            const team = new Team({
+                name: name.trim(),
+                slug,
+                description: description?.trim(),
+                ownerId: user._id,
+                members: [{ userId: user._id, role: 'Admin' }],
+            });
+            await team.save();
+
+            // Add this team to the user's teamIds array
+            await User.updateOne({ _id: user._id }, { $addToSet: { teamIds: team._id } });
+
+            res.status(201).json({ team });
+        } catch (error) {
+            console.error('Error creating team:', error);
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+
+    // GET /api/v1/teams – list teams for the authenticated user
+    const getMyTeams = async (req: Request, res: Response) => {
+        try {
+            const steamUser = req.user as any;
+            if (!steamUser) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const user = await User.findOne({ steamId: steamUser.id });
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            const teams = await Team.find({ _id: { $in: user.teamIds } });
+            res.status(200).json({ teams });
+        } catch (error) {
+            console.error('Error fetching teams:', error);
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+
+    return { createTeam, getMyTeams };
+}
+
+export default buildTeamController;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import helmet from 'helmet';
 import bodyParser from 'body-parser';
 import { IConfiguration } from './types/index.js';
 import database from './controllers/db/database.js';
-import { buildUserRouter , buildGenerationRouter, buildAuthRouter } from './routes/v1/index.js';
+import { buildUserRouter , buildGenerationRouter, buildAuthRouter, buildTeamRouter } from './routes/v1/index.js';
 import buildDocsRouter from './routes/v1/docs.js';
 import { initializeFFmpeg } from './config/ffmpeg.js';
 
@@ -50,6 +50,9 @@ app.use(authMiddleware);
 app.use('/auth', authRouter);
 
 app.use('/api/v1/users', buildUserRouter());
+
+// US-002: Team management endpoints (create team, list teams)
+app.use('/api/v1/teams', buildTeamRouter());
 
 app.use((req, res, next) => {
     // Middleware para manejar errores

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import helmet from 'helmet';
 import bodyParser from 'body-parser';
 import { IConfiguration } from './types/index.js';
 import database from './controllers/db/database.js';
-import { buildUserRouter , buildGenerationRouter, buildAuthRouter, buildTeamRouter } from './routes/v1/index.js';
+import { buildUserRouter , buildGenerationRouter, buildAuthRouter, buildTeamRouter, buildProjectRouter } from './routes/v1/index.js';
 import buildDocsRouter from './routes/v1/docs.js';
 import { initializeFFmpeg } from './config/ffmpeg.js';
 
@@ -53,6 +53,9 @@ app.use('/api/v1/users', buildUserRouter());
 
 // US-002: Team management endpoints (create team, list teams)
 app.use('/api/v1/teams', buildTeamRouter());
+
+// US-003: Project management endpoints (create project, list/get projects)
+app.use('/api/v1/projects', buildProjectRouter());
 
 app.use((req, res, next) => {
     // Middleware para manejar errores

--- a/src/middleware/acl.ts
+++ b/src/middleware/acl.ts
@@ -1,0 +1,82 @@
+/**
+ * US-001: ACL middleware for team-based access control.
+ * Ensures that only team members can access team-gated resources.
+ */
+import type { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
+import { Project, Team } from '../controllers/db/schemas.js';
+
+/**
+ * Express middleware that verifies the authenticated user belongs to the team
+ * associated with the requested project (resolved from req.params.projectId).
+ *
+ * Usage: router.get('/projects/:projectId/...', requireTeamMembership, handler)
+ */
+export async function requireTeamMembership(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const user = req.user as { _id?: string; steamId?: string } | undefined;
+
+  if (!user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { projectId, teamId } = req.params;
+
+  try {
+    let resolvedTeamId: string | undefined = teamId;
+
+    // If we have a projectId, resolve the teamId from the project
+    if (projectId && !resolvedTeamId) {
+      if (!mongoose.Types.ObjectId.isValid(projectId)) {
+        res.status(400).json({ error: 'Invalid project ID' });
+        return;
+      }
+      const project = await Project.findById(projectId).select('teamId').lean();
+      if (!project) {
+        res.status(404).json({ error: 'Project not found' });
+        return;
+      }
+      resolvedTeamId = project.teamId.toString();
+    }
+
+    if (!resolvedTeamId) {
+      res.status(400).json({ error: 'Team or project ID required' });
+      return;
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(resolvedTeamId)) {
+      res.status(400).json({ error: 'Invalid team ID' });
+      return;
+    }
+
+    // Look up the team and check membership
+    const team = await Team.findById(resolvedTeamId)
+      .select('ownerId members')
+      .lean();
+
+    if (!team) {
+      res.status(404).json({ error: 'Team not found' });
+      return;
+    }
+
+    const userId = (user as any)._id?.toString() ?? (user as any).id?.toString();
+
+    const isOwner = team.ownerId.toString() === userId;
+    const isMember = team.members.some((m) => m.userId.toString() === userId);
+
+    if (!isOwner && !isMember) {
+      res.status(403).json({ error: 'Forbidden: not a team member' });
+      return;
+    }
+
+    // Attach team to request for downstream handlers
+    (req as any).team = team;
+    next();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/middleware/populate.ts
+++ b/src/middleware/populate.ts
@@ -1,0 +1,61 @@
+/**
+ * US-001: Middleware to populate MongoDB associations.
+ * Attaches populated data to requests so route handlers don't repeat queries.
+ */
+import type { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
+import { Project } from '../controllers/db/schemas.js';
+
+/**
+ * Populates a project document with its team members using MongoDB $lookup.
+ * Attaches the result to req.populatedProject.
+ *
+ * Usage: router.get('/projects/:projectId', populateProject, handler)
+ */
+export async function populateProject(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const { projectId } = req.params;
+
+  if (!projectId || !mongoose.Types.ObjectId.isValid(projectId)) {
+    res.status(400).json({ error: 'Invalid project ID' });
+    return;
+  }
+
+  try {
+    // Use $lookup to join project -> team -> members (users) in a single query
+    const results = await Project.aggregate([
+      { $match: { _id: new mongoose.Types.ObjectId(projectId) } },
+      {
+        $lookup: {
+          from: 'teams',
+          localField: 'teamId',
+          foreignField: '_id',
+          as: 'team',
+        },
+      },
+      { $unwind: { path: '$team', preserveNullAndEmptyArrays: true } },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'team.members.userId',
+          foreignField: '_id',
+          as: 'teamMembers',
+          pipeline: [{ $project: { steamId: 1, displayName: 1, avatarUrl: 1 } }],
+        },
+      },
+    ]);
+
+    if (!results.length) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+
+    (req as any).populatedProject = results[0];
+    next();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/migrations/001-add-team-associations.ts
+++ b/src/migrations/001-add-team-associations.ts
@@ -1,0 +1,68 @@
+/**
+ * US-001: Migration – add team association fields to existing collections.
+ *
+ * Run with:
+ *   npx tsx src/migrations/001-add-team-associations.ts
+ *
+ * Safe to run multiple times (idempotent via $setOnInsert / default values).
+ */
+import mongoose from 'mongoose';
+
+const MONGO_URI =
+  process.env.AZURE_COSMOS_CONNECTIONSTRING ||
+  process.env.DATABASE_URL ||
+  'mongodb://localhost:27017/cs_ai_analyzer';
+
+async function runMigration(): Promise<void> {
+  await mongoose.connect(MONGO_URI);
+  console.log('Connected to MongoDB:', MONGO_URI);
+
+  const db = mongoose.connection.db;
+  if (!db) throw new Error('Database connection not available');
+
+  // 1. Add teamIds array (default []) to all Users that lack the field
+  const usersResult = await db.collection('users').updateMany(
+    { teamIds: { $exists: false } },
+    { $set: { teamIds: [] } }
+  );
+  console.log(`Users updated: ${usersResult.modifiedCount}`);
+
+  // 2. Ensure indexes on Users.teamIds for fast team-membership queries
+  await db.collection('users').createIndex({ teamIds: 1 }, { background: true });
+  console.log('Index on users.teamIds ensured');
+
+  // 3. Ensure Teams collection exists with required indexes
+  const teamsColl = await db
+    .listCollections({ name: 'teams' })
+    .toArray();
+  if (teamsColl.length === 0) {
+    await db.createCollection('teams');
+    console.log('Created teams collection');
+  }
+  await db.collection('teams').createIndex({ slug: 1 }, { unique: true, background: true });
+  await db.collection('teams').createIndex({ ownerId: 1 }, { background: true });
+  await db.collection('teams').createIndex({ 'members.userId': 1 }, { background: true });
+  console.log('Indexes on teams collection ensured');
+
+  // 4. Ensure Projects collection exists with required indexes
+  const projectsColl = await db
+    .listCollections({ name: 'projects' })
+    .toArray();
+  if (projectsColl.length === 0) {
+    await db.createCollection('projects');
+    console.log('Created projects collection');
+  }
+  await db.collection('projects').createIndex({ teamId: 1 }, { background: true });
+  await db
+    .collection('projects')
+    .createIndex({ ticketSlug: 1 }, { unique: true, background: true });
+  console.log('Indexes on projects collection ensured');
+
+  await mongoose.disconnect();
+  console.log('Migration 001 completed successfully.');
+}
+
+runMigration().catch((err) => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -2,3 +2,4 @@ export { default as buildUserRouter } from './user.js';
 export { default as buildGenerationRouter } from './generation.js';
 export { default as buildAuthRouter } from './auth.js';
 export { default as buildTeamRouter } from './team.js';
+export { default as buildProjectRouter } from './project.js';

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -1,3 +1,4 @@
 export { default as buildUserRouter } from './user.js';
 export { default as buildGenerationRouter } from './generation.js';
 export { default as buildAuthRouter } from './auth.js';
+export { default as buildTeamRouter } from './team.js';

--- a/src/routes/v1/project.ts
+++ b/src/routes/v1/project.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import buildProjectController from '../../controllers/project.js';
+
+function buildProjectRouter() {
+    const router = express.Router();
+    const { createProject, getTeamProjects, getProject } = buildProjectController();
+
+    // Create a new project linked to a team
+    router.post('/', createProject);
+
+    // Get a single project by ID (ACL enforced in controller)
+    router.get('/:projectId', getProject);
+
+    // List projects for a specific team
+    router.get('/team/:teamId', getTeamProjects);
+
+    return router;
+}
+
+export default buildProjectRouter;

--- a/src/routes/v1/team.ts
+++ b/src/routes/v1/team.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import buildTeamController from '../../controllers/team.js';
+
+function buildTeamRouter() {
+    const router = express.Router();
+    const { createTeam, getMyTeams } = buildTeamController();
+
+    // List teams for the authenticated user
+    router.get('/', getMyTeams);
+
+    // Create a new team
+    router.post('/', createTeam);
+
+    return router;
+}
+
+export default buildTeamRouter;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,4 +1,4 @@
-import type { IUserModel, IGenerationModel } from '../controllers/db/schemas.js';
+import type { IUserModel, IGenerationModel, ITeamModel, IProjectModel } from '../controllers/db/schemas.js';
 import { ISteamProfile } from './auth.js';
 
 export interface Database {


### PR DESCRIPTION
## US-003 - Create Project Linked to Team

### What was implemented
- `POST /api/v1/projects` – create a project document in MongoDB linked to a teamId, with slug validation and ACL enforcement
- `GET /api/v1/projects/:projectId` – get a single project (team members only)
- `GET /api/v1/projects/team/:teamId` – list all projects for a team (team members only)
- Slug validation: 3-4 uppercase letters followed by a hyphen (e.g., `TKT-`)
- Returns `firstTicketExample` (e.g., `TKT-001`) in create/get project responses
- ACL enforced: only team members/owners can create or view projects

### Files changed
- `src/controllers/project.ts` (new)
- `src/routes/v1/project.ts` (new)
- `src/routes/v1/index.ts` (export buildProjectRouter)
- `src/index.ts` (register `/api/v1/projects` route)

### Quality
- Typecheck passes (`npx tsc --noEmit`)
- All existing tests pass (`npm test`)

No browser tools available – manually verify project creation via API calls after deployment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds team-linked project creation and viewing with access controls, addressing US-003. Also introduces team APIs and an auth redirect to guide new users into team setup.

- **New Features**
  - Project APIs: POST /api/v1/projects, GET /api/v1/projects/:projectId, GET /api/v1/projects/team/:teamId
  - Team APIs: GET /api/v1/teams, POST /api/v1/teams
  - Slug validation (e.g., TKT-) with firstTicketExample in responses (e.g., TKT-001)
  - ACL: only team owners/members can create or view projects; middleware added for team checks
  - Schemas and indexes: Team, Project, and user.teamIds for faster membership lookups
  - Auth: after Steam login, users without teams are redirected to set up a team

- **Migration**
  - Run: npx tsx src/migrations/001-add-team-associations.ts

<sup>Written for commit 884e0b15275830e94602e1c98b44a2395f573677. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

