### PR TITLE
feat: US-001 - Update MongoDB Schemas for Users, Teams, and Projects

### DIFF
--- a/src/controllers/db/schemas.ts
+++ b/src/controllers/db/schemas.ts
@@ -1,11 +1,20 @@
-import mongoose, { Schema } from 'mongoose';
+import mongoose, { Schema, Types } from 'mongoose';
 
-// Define the schema for the User model
+// ─── Team membership entry ───────────────────────────────────────────────────
+
+export interface ITeamMembership {
+  teamId: Types.ObjectId;
+  role: string;
+}
+
+// ─── User model ──────────────────────────────────────────────────────────────
+
 export interface IUserModel extends Document {
   steamId: string;
   displayName: string;
   profileUrl: string;
   avatarUrl: string;
+  teams: ITeamMembership[];
   communityvisibilitystate?: number;
   profilestate?: number;
   personaname?: string;
@@ -25,17 +34,48 @@ export interface IUserModel extends Document {
   locstatecode?: string;
 }
 
+// ─── Team model ───────────────────────────────────────────────────────────────
+
+export interface ITeamModel extends Document {
+  name: string;
+  description?: string;
+  ownerId: Types.ObjectId;
+  members: Array<{ userId: Types.ObjectId; role: string }>;
+  projects: Types.ObjectId[];
+  active: boolean;
+}
+
+// ─── Project model ────────────────────────────────────────────────────────────
+
+export interface IProjectModel extends Document {
+  name: string;
+  teamId: Types.ObjectId;
+  slug: string;
+  statusCategories: string[];
+  active: boolean;
+}
+
+// ─── Generation model ─────────────────────────────────────────────────────────
+
 export interface IGenerationModel extends Document {
   steamId: string;
   dateTime: string;
   responseLLM: string;
 }
 
+// ─── Schemas ──────────────────────────────────────────────────────────────────
+
+const teamMembershipSchema = new Schema({
+  teamId: { type: Schema.Types.ObjectId, ref: 'Teams', required: true },
+  role: { type: String, required: true, default: 'viewer' },
+}, { _id: false });
+
 const userSchema = new Schema({
     steamId: { type: String, required: true, unique: true },
     displayName: { type: String, required: true },
     profileUrl: { type: String, required: true },
     avatarUrl: { type: String, required: false },
+    teams: { type: [teamMembershipSchema], default: [] },
     communityvisibilitystate: { type: Number, required: false },
     profilestate: { type: Number, required: false },
     personaname: { type: String, required: false },
@@ -57,6 +97,35 @@ const userSchema = new Schema({
     timestamps: true,
 });
 
+const teamMemberSchema = new Schema({
+  userId: { type: Schema.Types.ObjectId, ref: 'Users', required: true },
+  role: { type: String, required: true, default: 'viewer' },
+}, { _id: false });
+
+const teamSchema = new Schema({
+    name: { type: String, required: true, maxlength: 100 },
+    description: { type: String, required: false, maxlength: 500 },
+    ownerId: { type: Schema.Types.ObjectId, ref: 'Users', required: true },
+    members: { type: [teamMemberSchema], default: [] },
+    projects: [{ type: Schema.Types.ObjectId, ref: 'Projects' }],
+    active: { type: Boolean, default: true },
+}, {
+    timestamps: true,
+});
+
+const projectSchema = new Schema({
+    name: { type: String, required: true },
+    teamId: { type: Schema.Types.ObjectId, ref: 'Teams', required: true },
+    slug: { type: String, required: true },
+    statusCategories: { type: [String], default: ['Backlog', 'Todo', 'In Progress', 'Done'] },
+    active: { type: Boolean, default: true },
+}, {
+    timestamps: true,
+});
+
+// Unique slug per team
+projectSchema.index({ teamId: 1, slug: 1 }, { unique: true });
+
 const generationSchema = new Schema({
     steamId: { type: String, required: true },
     dateTime: { type: Date, default: Date.now },
@@ -66,5 +135,7 @@ const generationSchema = new Schema({
 });
 
 export const User = mongoose.model<IUserModel>('Users', userSchema);
+export const Team = mongoose.model<ITeamModel>('Teams', teamSchema);
+export const Project = mongoose.model<IProjectModel>('Projects', projectSchema);
 export const Generation = mongoose.model<IGenerationModel>('Generations', generationSchema);
 

--- a/src/migrations/001-add-teams-projects-schemas.ts
+++ b/src/migrations/001-add-teams-projects-schemas.ts
@@ -1,0 +1,45 @@
+/**
+ * Migration 001: Add Teams and Projects schemas, update User with teams array
+ *
+ * This migration:
+ * 1. Ensures the Teams collection exists with required indexes
+ * 2. Ensures the Projects collection exists with required indexes
+ * 3. Adds the `teams` field (default []) to existing User documents that lack it
+ *
+ * Safe to run multiple times (idempotent).
+ */
+import mongoose from 'mongoose';
+import { User, Team, Project } from '../controllers/db/schemas.js';
+
+export async function up(): Promise<void> {
+  console.log('[Migration 001] Starting...');
+
+  // Ensure Teams collection and index exist
+  await Team.createIndexes();
+  console.log('[Migration 001] Teams indexes ensured.');
+
+  // Ensure Projects collection and indexes exist (unique slug per team)
+  await Project.createIndexes();
+  console.log('[Migration 001] Projects indexes ensured.');
+
+  // Backfill `teams: []` on existing User documents that don't have it
+  const result = await (User as any).updateMany(
+    { teams: { $exists: false } },
+    { $set: { teams: [] } }
+  );
+  console.log(`[Migration 001] Updated ${result.modifiedCount} user document(s) with empty teams array.`);
+
+  console.log('[Migration 001] Done.');
+}
+
+// Allow running directly: tsx src/migrations/001-add-teams-projects-schemas.ts
+if (process.argv[1] && process.argv[1].endsWith('001-add-teams-projects-schemas.ts')) {
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/cs_ai_analyzer';
+  mongoose.connect(uri).then(async () => {
+    await up();
+    await mongoose.disconnect();
+  }).catch((err) => {
+    console.error('[Migration 001] Error:', err);
+    process.exit(1);
+  });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { Database } from './database.js';
 export type { IAuthentication, ISteamProfile } from './auth.js';
-export type { IUserModel, IGenerationModel } from '../controllers/db/schemas.js';
+export type { IUserModel, ITeamModel, IProjectModel, ITeamMembership, IGenerationModel } from '../controllers/db/schemas.js';
 export type { LLMProvider, LLMResponse } from './llm.js';
 export type { IConfiguration } from './configuration.js';
 export type { IGenerationController, IGeneration } from './generations.js';


### PR DESCRIPTION
## US-001 - Update MongoDB Schemas for Users, Teams, and Projects

### Changes
- Added `teams` array (`{teamId: ObjectId, role: String}`) to User model
- Created `Team` schema with `ownerId`, `members` array, `projects` array, and `active` flag
- Created `Project` schema with required `teamId` foreign key, `slug` field, `statusCategories`, and `active` flag
- Added unique compound index `(teamId, slug)` on Projects collection
- Implemented idempotent migration script `001-add-teams-projects-schemas.ts`
- Updated `types/index.ts` to export new interfaces

### Acceptance Criteria
- ✅ User model has `teams: [{teamId: ObjectId, role: String}]`
- ✅ Team model has `projects: [ObjectId]`
- ✅ Project schema has `teamId: ObjectId` as required foreign key
- ✅ Migration script implemented with Mongoose
- ✅ Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Teams and Projects to our MongoDB data model and adds team memberships to Users to enable team-based projects for US-001. Includes a unique (teamId, slug) constraint and an idempotent migration.

- **New Features**
  - User: teams [{teamId: ObjectId, role: string}]
  - Team: ownerId, members[], projects[], active
  - Project: required teamId, slug, statusCategories, active + unique (teamId, slug)
  - Exported ITeamModel, IProjectModel, ITeamMembership types

- **Migration**
  - Run migration 001 to create indexes and backfill users with teams: []
  - Safe to run multiple times (no data loss)

<sup>Written for commit 405f4e0ff02b85bc18527fc2c4479c7b82adddb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

